### PR TITLE
fix location of sitemap

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -40,11 +40,6 @@ jobs:
       run: |
         pip install -r requirements.txt
 
-    # Generate sitemap before building the book
-    - name: Generate sitemap
-      run: |
-        python generate_site_map.py
-
     # (optional) Cache your executed notebooks between runs
     # if you have config:
     # execute:
@@ -59,7 +54,11 @@ jobs:
     - name: Build the book
       run: |
         jupyter-book build .
-
+        
+    # Generate sitemap before building the book
+    - name: Generate sitemap
+      run: |
+        python generate_site_map.py
         
     # Upload the book's HTML as an artifact
     - name: Upload artifact

--- a/generate_site_map.py
+++ b/generate_site_map.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime
 
 site_url = "https://mmann1123.github.io/YouthMappersAcademy/"  # <-- Update this to your actual site URL
-html_dir = "../"
+html_dir = "_build/html"
 sitemap_path = os.path.join(html_dir, "sitemap2.xml")
 
 urls = []


### PR DESCRIPTION
This pull request updates the sitemap generation process for the book deployment workflow and fixes the output directory for the generated sitemap. The most important changes are grouped below:

**Workflow improvements:**

* Moved the "Generate sitemap" step in `.github/workflows/deploy-book.yml` to run after the book is built, ensuring the sitemap is generated from the latest HTML output.  

**Sitemap generation fix:**

* Updated `generate_site_map.py` to use the correct HTML build directory (`_build/html`) instead of the parent directory, so the sitemap reflects the actual deployed content.